### PR TITLE
Including counting function/method to milliseconds & repo organizing

### DIFF
--- a/ioc-interface/SI-CountingPRU_Socket.py
+++ b/ioc-interface/SI-CountingPRU_Socket.py
@@ -165,7 +165,7 @@ class Communication(Thread):
                                 if message[1] == 0x10:
                                     # TimeBase
                                     if message[4] == 0x00:
-                                        con.send(sendVariable(message[4], TimeBase, 2))
+                                        con.send(sendVariable(message[4], int(TimeBase), 2))
                                     elif message[4] <= 0x08:
                                         con.send(sendVariable(message[4], Counting[message[4] - 1], 4))
 


### PR DESCRIPTION
New function/method available: `Counting_ms(long millisecs)` performs counting using millisecond unit.
Version v1.1.0


Repository contains only latest release (older ones in previous tag)